### PR TITLE
Fixed Manhattan spelling

### DIFF
--- a/pathfinding/core/heuristic.py
+++ b/pathfinding/core/heuristic.py
@@ -13,8 +13,8 @@ def null(dx, dy):
     return 0
 
 
-def manhatten(dx, dy):
-    """manhatten heuristics"""
+def manhattan(dx, dy):
+    """manhattan heuristics"""
     return dx + dy
 
 

--- a/pathfinding/finder/a_star.py
+++ b/pathfinding/finder/a_star.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import heapq  # used for the so colled "open list" that stores known nodes
-from pathfinding.core.heuristic import manhatten, octile
+from pathfinding.core.heuristic import manhattan, octile
 from pathfinding.core.util import backtrace, bi_backtrace
 from pathfinding.core.diagonal_movement import DiagonalMovement
 from .finder import Finder, TIME_LIMIT, MAX_RUNS, BY_END
@@ -14,7 +14,7 @@ class AStarFinder(Finder):
         """
         find shortest path using A* algorithm
         :param heuristic: heuristic used to calculate distance of 2 points
-            (defaults to manhatten)
+            (defaults to manhattan)
         :param weight: weight for the edges
         :param diagonal_movement: if diagonal movement is allowed
             (see enum in diagonal_movement)
@@ -33,7 +33,7 @@ class AStarFinder(Finder):
 
         if not heuristic:
             if diagonal_movement == DiagonalMovement.never:
-                self.heuristic = manhatten
+                self.heuristic = manhattan
             else:
                 # When diagonal movement is allowed the manhattan heuristic is
                 # not admissible it should be octile instead

--- a/pathfinding/finder/best_first.py
+++ b/pathfinding/finder/best_first.py
@@ -13,7 +13,7 @@ class BestFirst(AStarFinder):
         """
         find shortest path using BestFirst algorithm
         :param heuristic: heuristic used to calculate distance of 2 points
-            (defaults to manhatten)
+            (defaults to manhattan)
         :param weight: weight for the edges
         :param diagonal_movement: if diagonal movement is allowed
             (see enum in diagonal_movement)

--- a/pathfinding/finder/bi_a_star.py
+++ b/pathfinding/finder/bi_a_star.py
@@ -16,7 +16,7 @@ class BiAStarFinder(AStarFinder):
         """
         find shortest path using Bi-A* algorithm
         :param heuristic: heuristic used to calculate distance of 2 points
-            (defaults to manhatten)
+            (defaults to manhattan)
         :param weight: weight for the edges
         :param diagonal_movement: if diagonal movement is allowed
             (see enum in diagonal_movement)

--- a/pathfinding/finder/finder.py
+++ b/pathfinding/finder/finder.py
@@ -34,7 +34,7 @@ class Finder(object):
         """
         find shortest path
         :param heuristic: heuristic used to calculate distance of 2 points
-            (defaults to manhatten)
+            (defaults to manhattan)
         :param weight: weight for the edges
         :param diagonal_movement: if diagonal movement is allowed
             (see enum in diagonal_movement)

--- a/pathfinding/finder/ida_star.py
+++ b/pathfinding/finder/ida_star.py
@@ -1,5 +1,5 @@
 import time
-from pathfinding.core.heuristic import manhatten, octile
+from pathfinding.core.heuristic import manhattan, octile
 from pathfinding.core.diagonal_movement import DiagonalMovement
 from pathfinding.core.node import Node
 from .finder import Finder, TIME_LIMIT, MAX_RUNS
@@ -35,7 +35,7 @@ class IDAStarFinder(Finder):
         self.track_recursion = track_recursion
         if not heuristic:
             if diagonal_movement == DiagonalMovement.never:
-                self.heuristic = manhatten
+                self.heuristic = manhattan
             else:
                 # When diagonal movement is allowed the manhattan heuristic is
                 # not admissible it should be octile instead


### PR DESCRIPTION
Replaced "manhatten" with "manhattan".