### PR TITLE
Adding __repr__ methods to Grid, Node and Finder

### DIFF
--- a/pathfinding/core/grid.py
+++ b/pathfinding/core/grid.py
@@ -223,3 +223,9 @@ class Grid(object):
         if border:
             data += '\n+{}+'.format('-' * len(self.nodes[0]))
         return data
+    
+    def __repr__(self):
+        """
+        return a human readable representation
+        """
+        return f"< {self.__class__.__name__} width={self.width} height={self.height} >"

--- a/pathfinding/core/node.py
+++ b/pathfinding/core/node.py
@@ -75,3 +75,9 @@ class Node:
         self.retain_count = 0
         # used for IDA* and Jump-Point-Search
         self.tested = False
+
+    def __repr__(self):
+        """
+        return a human readable representation
+        """
+        return f"< {self.__class__.__name__} x={self.x} y={self.y} >"

--- a/pathfinding/core/node.py
+++ b/pathfinding/core/node.py
@@ -75,9 +75,3 @@ class Node:
         self.retain_count = 0
         # used for IDA* and Jump-Point-Search
         self.tested = False
-
-    def __repr__(self):
-        """
-        return a human readable representation
-        """
-        return f"< {self.__class__.__name__} x={self.x} y={self.y} >"

--- a/pathfinding/finder/finder.py
+++ b/pathfinding/finder/finder.py
@@ -179,3 +179,9 @@ class Finder(object):
 
         # failed to find path
         return [], self.runs
+    
+    def __repr__(self):
+        """
+        return a human readable representation
+        """
+        return f"< {self.__class__.__name__} diagonal_movement={self.diagonal_movement} >"


### PR DESCRIPTION
I've always found the ability to just print an object very handy for debugging so I've taken the liberty of adding it to some of the key objects of the library.