### PR TITLE
Added bi-directional breadth-first-search

### DIFF
--- a/pathfinding/finder/__init__.py
+++ b/pathfinding/finder/__init__.py
@@ -1,2 +1,2 @@
-__all__ = ['a_star', 'best_first', 'bi_a_star', 'breadth_first', 'dijkstra',
-           'finder', 'ida_star']
+__all__ = ['a_star', 'best_first', 'bi_a_star', 'bi_breadth_first',
+           'breadth_first', 'dijkstra', 'finder', 'ida_star']

--- a/pathfinding/finder/bi_breadth_first.py
+++ b/pathfinding/finder/bi_breadth_first.py
@@ -1,0 +1,85 @@
+import time
+from collections import deque
+
+from .finder import BY_END, BY_START, Finder, MAX_RUNS, TIME_LIMIT
+from ..core.diagonal_movement import DiagonalMovement
+from ..core.util import bi_backtrace
+
+
+class BiBreadthFirstFinder(Finder):
+    """
+    Bidirectional Breadth-First-Search (Bi-BFS)
+    """
+
+    def __init__(
+        self,
+        diagonal_movement=DiagonalMovement.never,
+        time_limit=TIME_LIMIT,
+        max_runs=MAX_RUNS,
+    ):
+        super(BiBreadthFirstFinder, self).__init__(
+            weighted=False,
+            diagonal_movement=diagonal_movement,
+            time_limit=time_limit,
+            max_runs=max_runs,
+        )
+
+    def _search_level(self, grid, queue, opened_by, looking_for):
+        """
+        Search one level from the given queue.
+        """
+        level_size = len(queue)
+        for _ in range(level_size):
+            self.runs += 1
+            self.keep_running()
+
+            node = queue.popleft()
+            node.closed = True
+
+            neighbors = self.find_neighbors(grid, node)
+            for neighbor in neighbors:
+                if neighbor.opened == opened_by:
+                    continue
+                if neighbor.opened == looking_for:
+                    if opened_by == BY_START:
+                        return bi_backtrace(node, neighbor)
+                    else:
+                        return bi_backtrace(neighbor, node)
+
+                neighbor.opened = opened_by
+                neighbor.parent = node
+                queue.append(neighbor)
+        return None
+
+    def find_path(self, start, end, grid):
+        """
+        Find a path from start to end node on grid using Bi-BFS
+        :param start: start node
+        :param end: end node
+        :param grid: grid that stores all possible nodes
+        :return:
+        """
+        self.clean_grid(grid)
+
+        self.start_time = time.time()
+        self.runs = 0
+
+        start_queue = deque([start])
+        start.opened = BY_START
+        start.parent = None
+
+        end_queue = deque([end])
+        end.opened = BY_END
+        end.parent = None
+
+        while start_queue and end_queue:
+            path = self._search_level(grid, start_queue, BY_START, BY_END)
+            if path:
+                return path, self.runs
+
+            path = self._search_level(grid, end_queue, BY_END, BY_START)
+            if path:
+                return path, self.runs
+
+        # failed to find path
+        return [], self.runs

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -12,6 +12,7 @@ from pathfinding.finder.finder import ExecutionRunsException
 from pathfinding.finder.finder import ExecutionTimeException
 from pathfinding.finder.ida_star import IDAStarFinder
 from pathfinding.finder.msp import MinimumSpanningTree
+from pathfinding.finder.bi_breadth_first import BiBreadthFirstFinder
 
 import pytest
 
@@ -21,8 +22,8 @@ BASE_PATH = os.path.abspath(os.path.dirname(__file__))
 # test scenarios from Pathfinding.JS
 scenarios = os.path.join(BASE_PATH, 'path_test_scenarios.json')
 data = json.load(open(scenarios, 'r', encoding='utf-8'))
-finders = [AStarFinder, BestFirst, BiAStarFinder, DijkstraFinder,
-           IDAStarFinder, BreadthFirstFinder, MinimumSpanningTree]
+finders = [AStarFinder, BestFirst, BiAStarFinder, BiBreadthFirstFinder,
+           DijkstraFinder, IDAStarFinder, BreadthFirstFinder, MinimumSpanningTree]
 TIME_LIMIT = 10  # give it a 10 second limit.
 
 


### PR DESCRIPTION
Hi, I've added Bi-directional Breadth First Search in this PR.

The implementation searches from both the start and end nodes, expanding one full level at a time to guarantee it finds the shortest path. The runs counter is incremented per-node (not per-level). This passes all existing tests.

P.S. I'm participating in [Hacktoberfest](https://hacktoberfest.com/). If this PR is accepted, the `hacktoberfest-accepted` label would be greatly appreciated.