### PR TITLE
Update type hint in Graph.__init__

### DIFF
--- a/pathfinding/core/graph.py
+++ b/pathfinding/core/graph.py
@@ -4,7 +4,7 @@ from .node import GraphNode
 
 class Graph:
     def __init__(
-            self, edges: List[Set] = None, nodes: Dict[int, GraphNode] = None,
+            self, edges: List[List] = None, nodes: Dict[int, GraphNode] = None,
             bi_directional: bool = False):
         # edges defined by node-from, node-to and its cost
         self.edges = edges if edges else []


### PR DESCRIPTION
A type hint for edges parameter in Graph constructor is wrong, as it has to be a List of Lists. The current List of Sets would fail on the attempts to subscript the Set members.
Providing a correct type - List of Lists - is also demonstrated in examples.