### PR TITLE
Handle empty open list returning None from pop_node()

### DIFF
--- a/pathfinding/finder/a_star.py
+++ b/pathfinding/finder/a_star.py
@@ -54,6 +54,9 @@ class AStarFinder(Finder):
         """
         # pop node with minimum 'f' value
         node = open_list.pop_node()
+        if node is None:
+            # open list only held stale entries; nothing left to expand
+            return None
         node.closed = True
 
         # if reached the end position, construct the path and return it

--- a/pathfinding/finder/breadth_first.py
+++ b/pathfinding/finder/breadth_first.py
@@ -21,6 +21,9 @@ class BreadthFirstFinder(Finder):
 
     def check_neighbors(self, start, end, grid, open_list):
         node = open_list.pop_node()
+        if node is None:
+            # open list only held stale entries; nothing left to expand
+            return None
         node.closed = True
 
         if node == end:

--- a/pathfinding/finder/msp.py
+++ b/pathfinding/finder/msp.py
@@ -38,6 +38,9 @@ class MinimumSpanningTree(Finder):
             self.keep_running()
 
             node = open_list.pop_node()
+            if node is None:
+                # open list only held stale entries; nothing left to expand
+                break
             node.closed = True
             yield node
 

--- a/test/test_path.py
+++ b/test/test_path.py
@@ -87,6 +87,27 @@ def test_path_diagonal():
             assert len(path) == scenario['expectedDiagonalLength']
 
 
+def test_unreachable_only_when_no_obstacle():
+    # when the end is unreachable the open list can drain to only stale
+    # entries, so pop_node() returns None; the finder should report an empty
+    # path instead of crashing (issue #83)
+    matrix = [
+        [0, 0, 0, 0, 0, 1, 1],
+        [0, 1, 1, 1, 0, 1, 1],
+        [0, 1, 1, 1, 0, 1, 1],
+        [0, 1, 1, 1, 0, 1, 1],
+        [0, 1, 1, 1, 0, 1, 1],
+        [0, 0, 0, 0, 0, 1, 1],
+    ]
+    grid = Grid(matrix=matrix)
+    start = grid.node(1, 2)
+    end = grid.node(6, 3)
+    finder = AStarFinder(
+        diagonal_movement=DiagonalMovement.only_when_no_obstacle)
+    path, _ = finder.find_path(start, end, grid)
+    assert path == []
+
+
 def test_max_runs():
     grid, start, end = grid_from_scenario(data[1])
     for find in finders:


### PR DESCRIPTION
Since 1.0.21 the heap's pop_node() can return None once the open list only holds stale entries, but len(open_list) still counts those entries so the finder loop keeps calling check_neighbors and crashes on node.closed = True. This is the AttributeError reported in #83 when the end is unreachable with DiagonalMovement.only_when_no_obstacle.

I added a guard at the three pop_node() call sites (a_star, breadth_first, msp) so a None result ends the expansion and the finder returns an empty path like it did in 1.0.20. Added a regression test using the grid from the issue.